### PR TITLE
Add support for Warhammer Imperium Maledictum

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@ or [directly copy the manifest link for the latest release](https://github.com/s
 - Tormenta20
 - Shadowdark RPG
 - Warhammer Fantasy Roleplay 4e (wfrp4e)
+- Warhammer 40,000: Imperium Maledictum (impmal)
 
 More can be added easily by request / PR!
 

--- a/scripts/system-compatibility.js
+++ b/scripts/system-compatibility.js
@@ -158,7 +158,15 @@ const systemBasedHpKeys = (actor) => {
       hpMax: 'system.stamina.max',
       zeroIsBad: true,
     }
-  } else {
+  } else if (game.system.id === 'impmal') {
+    if (actor.type !== 'vehicle')
+      return {
+        hpValue: 'system.combat.wounds.value',
+        hpMax: 'system.combat.wounds.max',
+        zeroIsBad: false,
+      }
+    else return undefined
+    } else {
     // not a supported system
     return undefined
   }


### PR DESCRIPTION
This add basic support for Warhammer 40,000: Imperium Maledictum game system. It also prevents displaying blood on vehicle type.